### PR TITLE
Update deprecated upload artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/ai-wearable-pcb/ato.yaml
+++ b/ai-wearable-pcb/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: 0.2.0
+requires-atopile: 0.2.0
 name: ai-wearable-pcb
 version: 1.0.0
 description: Ultra-small AI wearable PCB with camera, microphone, speaker, and eSIM

--- a/aiwearable/.github/workflows/ci.yml
+++ b/aiwearable/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           ato build --schematic --pcb --bom --placement
       - name: Upload build artefacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pcba-files
           path: build/

--- a/ato.yaml
+++ b/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/veramonitor.ato:Veramonitor

--- a/elec/src/ams1117-33/.github/workflows/ci.yml
+++ b/elec/src/ams1117-33/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/ams1117-33/ato.yaml
+++ b/elec/src/ams1117-33/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/ams1117-33.ato:AMS111733

--- a/elec/src/esp32-s3/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/ato.yaml
+++ b/elec/src/esp32-s3/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/esp32-s3.ato:ESP32S3

--- a/elec/src/esp32-s3/elec/src/bq24045dsqr/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/elec/src/bq24045dsqr/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/elec/src/bq24045dsqr/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/bq24045dsqr/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/bq24045dsqr.ato:BQ24040DSQR

--- a/elec/src/esp32-s3/elec/src/programming-headers/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/elec/src/programming-headers/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/elec/src/programming-headers/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/programming-headers/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/programming-headers.ato:ProgrammingHeaders

--- a/elec/src/esp32-s3/elec/src/sk6805-ec20/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/elec/src/sk6805-ec20/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/elec/src/sk6805-ec20/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/sk6805-ec20/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/sk6805-ec20.ato:SK6805EC20

--- a/elec/src/esp32-s3/elec/src/tf-01a/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/elec/src/tf-01a/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/elec/src/tf-01a/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/tf-01a/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/tf-01a.ato:TF_01A

--- a/elec/src/esp32-s3/elec/src/tps63020dsjr/.github/workflows/ci.yml
+++ b/elec/src/esp32-s3/elec/src/tps63020dsjr/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/esp32-s3/elec/src/tps63020dsjr/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/tps63020dsjr/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/tps63020dsjr.ato:TPS63020DSJR

--- a/elec/src/esp32-s3/elec/src/usb-connectors/ato.yaml
+++ b/elec/src/esp32-s3/elec/src/usb-connectors/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: usb-connectors.ato:USBCConn

--- a/elec/src/generics/ato.yaml
+++ b/elec/src/generics/ato.yaml
@@ -1,1 +1,1 @@
-ato-version: v0.2.0
+requires-atopile: v0.2.0

--- a/elec/src/jst-gh/.github/workflows/ci.yml
+++ b/elec/src/jst-gh/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/jst-gh/ato.yaml
+++ b/elec/src/jst-gh/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/jst-gh.ato:debug

--- a/elec/src/programming-headers/.github/workflows/ci.yml
+++ b/elec/src/programming-headers/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/programming-headers/ato.yaml
+++ b/elec/src/programming-headers/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/programming-headers.ato:ProgrammingHeaders

--- a/elec/src/qwiic-connectors/.github/workflows/ci.yml
+++ b/elec/src/qwiic-connectors/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/qwiic-connectors/ato.yaml
+++ b/elec/src/qwiic-connectors/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/qwiic-connectors.ato:QwiicConnectors

--- a/elec/src/rp2040/ato.yaml
+++ b/elec/src/rp2040/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: v0.2.16
+requires-atopile: v0.2.16
 builds:
   default:
     entry: RP2040Kit.ato:RP2040Kit

--- a/elec/src/sk6805-ec20/.github/workflows/ci.yml
+++ b/elec/src/sk6805-ec20/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker://ghcr.io/atopile/atopile-kicad
 
       - name: Upload Combined Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build

--- a/elec/src/sk6805-ec20/ato.yaml
+++ b/elec/src/sk6805-ec20/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: elec/src/sk6805-ec20.ato:SK6805EC20

--- a/elec/src/usb-connectors/ato.yaml
+++ b/elec/src/usb-connectors/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+requires-atopile: ^0.2.0
 builds:
   default:
     entry: usb-connectors.ato:USBCConn


### PR DESCRIPTION
Upgrade `actions/upload-artifact` to v4 to resolve deprecation errors.

GitHub deprecated `actions/upload-artifact@v3`, causing workflows to fail. This PR updates all instances to `v4`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7c05dfff-73a1-48bb-91ba-a4186d4ab259) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7c05dfff-73a1-48bb-91ba-a4186d4ab259)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)