### PR TITLE
Run atopile kicad container with config error

### DIFF
--- a/ato.yaml
+++ b/ato.yaml
@@ -7,39 +7,12 @@ builds:
   kailh-sw:
     entry: elec/src/kailh-sw.ato:KailhSW
 dependencies:
-- name: generics
-  version_spec: '@09ad6baeaab93d53b9b6c90069ac750f4161d76f'
-  link_broken: true
-  path: elec/src/generics
-- name: rp2040
-  version_spec: '@f6c06f3f01c257523d4c15ad5c5a48809b8914c8'
-  link_broken: true
-  path: elec/src/rp2040
-- name: qwiic-connectors
-  version_spec:
-  link_broken: true
-  path: elec/src/qwiic-connectors
-- name: jst-gh
-  version_spec:
-  link_broken: true
-  path: elec/src/jst-gh
-- name: esp32-s3
-  version_spec: '@84a3387cfa3fb6772459bec7b2bebbbded5790ec'
-  link_broken: true
-  path: elec/src/esp32-s3
-- name: usb-connectors
-  version_spec: '@1be66943895494857495c3afe24389a895b9fac8'
-  link_broken: true
-  path: elec/src/usb-connectors
-- name: sk6805-ec20
-  version_spec:
-  link_broken: true
-  path: elec/src/sk6805-ec20
-- name: programming-headers
-  version_spec: '@e3a6ca6b5b93e3c2db899aa7cc5a8fde17920abc'
-  link_broken: true
-  path: elec/src/programming-headers
-- name: ams1117-33
-  version_spec:
-  link_broken: true
-  path: elec/src/ams1117-33
+- generics@09ad6baeaab93d53b9b6c90069ac750f4161d76f
+- rp2040@f6c06f3f01c257523d4c15ad5c5a48809b8914c8
+- qwiic-connectors
+- jst-gh
+- esp32-s3@84a3387cfa3fb6772459bec7b2bebbbded5790ec
+- usb-connectors@1be66943895494857495c3afe24389a895b9fac8
+- sk6805-ec20
+- programming-headers@e3a6ca6b5b93e3c2db899aa7cc5a8fde17920abc
+- ams1117-33


### PR DESCRIPTION
Update `ato.yaml` dependency format to resolve 'Unable to extract tag using discriminator 'type'' error.

The `atopile` tool was failing with a `Configuration Error: Unable to extract tag using discriminator 'type': dependencies`. This error occurred because the `ato.yaml` file was using an object-based format for dependencies (e.g., `name`, `version_spec`, `path`), but `atopile` expected a simpler string-based format (e.g., `generics@09ad6baeaab93d53b9b6c90069ac750f4161d76f`) for parsing. Switching to the string format resolves the parsing issue.

---

[Open in Web](https://www.cursor.com/agents?id=bc-477c472f-05d5-4d7f-9fa0-390c03b3b04b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-477c472f-05d5-4d7f-9fa0-390c03b3b04b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)