### PR TITLE
Rebuild gerber files for pcb designs

### DIFF
--- a/.github/workflows/ai-wearable-build.yml
+++ b/.github/workflows/ai-wearable-build.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "aiwearable/**"
       - "ai-wearable-pcb/**"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Add `workflow_dispatch` trigger to enable manual GitHub Actions builds.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0989384d-d558-4e47-b725-9fee9606d09f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0989384d-d558-4e47-b725-9fee9606d09f)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)