### PR TITLE
Build project artifacts with ki-cad plugin setup

### DIFF
--- a/.github/workflows/ai-wearable-build.yml
+++ b/.github/workflows/ai-wearable-build.yml
@@ -20,6 +20,9 @@ jobs:
     strategy:
       matrix:
         target-dir: [ "aiwearable", "ai-wearable-pcb" ]
+    env:
+      # Disable the interactive first-run wizard so `ato build` never blocks in CI
+      ATO_CI: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build with atopile-kicad
+        env:
+          ATO_CI: "1"
         continue-on-error: true
         uses: docker://ghcr.io/atopile/atopile-kicad:latest
 


### PR DESCRIPTION
Disable `atopile`'s interactive first-run wizard in CI workflows.

The `atopile` CLI's initial setup wizard prompts for user input, which blocks non-interactive CI environments. Setting `ATO_CI=1` bypasses this wizard, allowing `ato` commands to run headlessly.

---

[Open in Web](https://www.cursor.com/agents?id=bc-aaa1ba81-fe5b-4157-91ff-a38231ef2e2a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-aaa1ba81-fe5b-4157-91ff-a38231ef2e2a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)