### PR TITLE
Install project dependencies and setup

### DIFF
--- a/aiwearable/.github/workflows/ci.yml
+++ b/aiwearable/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Disable the interactive first-run wizard so `ato build` never blocks in CI
+      ATO_CI: "1"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Add `ATO_CI` environment variable to `ci.yml` to prevent `ato build` from prompting for user input in CI.

---

[Open in Web](https://www.cursor.com/agents?id=bc-bcc1412d-42cc-4911-9e0c-a10fc82394d3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bcc1412d-42cc-4911-9e0c-a10fc82394d3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)