### PR TITLE
Checkout and build atopile project

### DIFF
--- a/.github/workflows/ci-fixed.yml
+++ b/.github/workflows/ci-fixed.yml
@@ -1,0 +1,126 @@
+name: CI Build (Fixed)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - izzymonitor
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build with atopile-kicad (with fixes)
+        env:
+          ATO_CI: "1"
+        run: |
+          # Run the Docker container with our fix script
+          docker run --rm \
+            -v ${{ github.workspace }}:/github/workspace \
+            -w /github/workspace \
+            -e ATO_CI=1 \
+            ghcr.io/atopile/atopile-kicad:latest \
+            bash -c '
+              echo "=== Applying fixes for known atopile/faebryk issues ==="
+              
+              # Run the fix script
+              if [ -f "fix_atopile_errors.py" ]; then
+                python3 fix_atopile_errors.py || echo "Fix script failed, continuing anyway"
+              fi
+              
+              # Alternative inline fix for the telemetry issue
+              echo "=== Applying inline telemetry fix ==="
+              python3 -c "
+import os
+import glob
+import re
+
+# Find and patch telemetry.py
+telemetry_files = glob.glob(\"/root/.local/share/uv/tools/atopile/lib/python*/site-packages/atopile/telemetry.py\")
+for tf in telemetry_files:
+    if os.path.exists(tf):
+        with open(tf, \"r\") as f:
+            content = f.read()
+        
+        # Add asdict import
+        if \"from dataclasses import\" not in content:
+            content = \"from dataclasses import asdict\\n\" + content
+        
+        # Fix yaml.dump call
+        content = re.sub(
+            r\"yaml\\.dump\\(config,\\s*f\\)\",
+            \"yaml.dump(asdict(config) if hasattr(config, \\\"__dataclass_fields__\\\") else config, f)\",
+            content
+        )
+        
+        with open(tf, \"w\") as f:
+            f.write(content)
+        print(f\"Patched {tf}\")
+
+# Find and patch dependencies.py
+deps_files = glob.glob(\"/root/.local/share/uv/tools/atopile/lib/python*/site-packages/faebryk/libs/project/dependencies.py\")
+for df in deps_files:
+    if os.path.exists(df):
+        with open(df, \"r\") as f:
+            content = f.read()
+        
+        # Fix error message handling
+        content = re.sub(
+            r\"(\\w+)\\.message\\b\",
+            r\"getattr(\\1, \\\"message\\\", getattr(\\1, \\\"error\\\", str(\\1)))\",
+            content
+        )
+        
+        with open(df, \"w\") as f:
+            f.write(content)
+        print(f\"Patched {df}\")
+"
+              
+              echo "=== Running atopile install ==="
+              atopile install || {
+                echo "=== atopile install failed, trying with --upgrade ==="
+                atopile install --upgrade || {
+                  echo "=== Both install attempts failed ==="
+                  exit 1
+                }
+              }
+              
+              echo "=== Build completed ==="
+            '
+
+      - name: Check build output
+        run: |
+          # List all files to see what was generated
+          echo "=== Listing all files in workspace ==="
+          find . -type f -name "*.zip" -o -name "*.csv" -o -name "*.pos" -o -name "*.kicad_*" | sort
+          
+          # Check if build directory exists
+          if [ -d "build" ]; then
+            echo "=== Build directory contents ==="
+            ls -la build/
+            find build -type f | sort
+          else
+            echo "Build directory does not exist"
+          fi
+          
+          # Check for any KiCad files generated
+          echo "=== Looking for KiCad files ==="
+          find . -name "*.kicad_pcb" -o -name "*.kicad_sch" | sort
+
+      - name: Upload Combined Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-artifacts
+          path: |
+            build/
+            **/*.kicad_pcb
+            **/*.kicad_sch
+            **/*.csv
+            **/*.pos
+            **/*.zip

--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -1,0 +1,70 @@
+name: CI Build (Simple)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - izzymonitor
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build with atopile-kicad (telemetry disabled)
+        env:
+          ATO_CI: "1"
+          ATOPILE_TELEMETRY: "false"
+          DO_NOT_TRACK: "1"
+        run: |
+          # Run the Docker container with telemetry disabled
+          docker run --rm \
+            -v ${{ github.workspace }}:/github/workspace \
+            -w /github/workspace \
+            -e ATO_CI=1 \
+            -e ATOPILE_TELEMETRY=false \
+            -e DO_NOT_TRACK=1 \
+            ghcr.io/atopile/atopile-kicad:latest \
+            bash -c '
+              # Disable telemetry in config if file exists
+              mkdir -p ~/.config/atopile
+              echo "telemetry: false" > ~/.config/atopile/config.yaml
+              
+              # Run atopile install
+              echo "=== Running atopile install ==="
+              atopile install
+              
+              echo "=== Build completed ==="
+            '
+
+      - name: Check build output
+        run: |
+          # List all files to see what was generated
+          echo "=== Listing all files in workspace ==="
+          find . -type f \( -name "*.zip" -o -name "*.csv" -o -name "*.pos" -o -name "*.kicad_*" \) | sort
+          
+          # Check if build directory exists
+          if [ -d "build" ]; then
+            echo "=== Build directory contents ==="
+            ls -la build/
+            find build -type f | sort
+          else
+            echo "Build directory does not exist"
+          fi
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-output
+          path: |
+            build/
+            **/*.kicad_pcb
+            **/*.kicad_sch
+            **/*.csv
+            **/*.pos
+            **/*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
           ATO_CI: "1"
         continue-on-error: true
         uses: docker://ghcr.io/atopile/atopile-kicad:latest
+        with:
+          entrypoint: /bin/bash
+          args: |
+            -c "
+            # First, run the fix script to patch known issues
+            python3 /github/workspace/fix_atopile_errors.py || true
+            
+            # Then run the atopile install command
+            atopile install
+            "
 
       - name: Check build output
         run: |

--- a/CI-FIX-README.md
+++ b/CI-FIX-README.md
@@ -1,0 +1,84 @@
+# CI Build Error Fix for ESPHome-Panel-example
+
+## Problem Description
+
+The GitHub Actions CI build is failing with two main errors:
+
+1. **Telemetry Serialization Error**: 
+   ```
+   RepresenterError: cannot represent an object: TelemetryConfig(telemetry=True, id=UUID('...'))
+   ```
+   This occurs because the `TelemetryConfig` dataclass cannot be serialized by the YAML dumper.
+
+2. **AttributeError in Dependencies**:
+   ```
+   AttributeError: 'PackagesApiHTTPError' object has no attribute 'message'
+   ```
+   This happens when the error handling code tries to access a non-existent `message` attribute.
+
+## Solutions
+
+I've created three different workflow files to address these issues:
+
+### 1. Simple Solution - Disable Telemetry (`ci-simple.yml`)
+The easiest fix is to disable telemetry entirely:
+- Sets environment variables to disable telemetry
+- Creates a config file that disables telemetry
+- This avoids the serialization issue completely
+
+### 2. Patch Solution - Fix the Code (`ci-fixed.yml`)
+This approach patches the problematic code directly:
+- Runs inline Python code to fix the telemetry serialization
+- Patches the error handling in dependencies.py
+- More robust but requires modifying the installed packages
+
+### 3. Original Workflow with Fix Script (`ci.yml`)
+Updated the original workflow to run the fix script:
+- Uses the existing `fix_atopile_errors.py` script
+- Applies patches before running atopile install
+
+## How to Use
+
+1. **For Quick Fix**: Use the `ci-simple.yml` workflow
+   ```bash
+   # In your GitHub Actions, use:
+   .github/workflows/ci-simple.yml
+   ```
+
+2. **For Comprehensive Fix**: Use the `ci-fixed.yml` workflow
+   ```bash
+   # This applies all patches and handles edge cases
+   .github/workflows/ci-fixed.yml
+   ```
+
+3. **To Test Locally**: Run the fix script
+   ```bash
+   python3 fix_atopile_errors.py
+   ```
+
+## Root Cause
+
+The issues stem from:
+1. The atopile telemetry system trying to serialize a dataclass without proper YAML representation
+2. The faebryk error handling assuming error objects have a `message` attribute when they might have `error` or other attributes
+
+These are upstream bugs in the atopile/faebryk packages that should be reported to their maintainers.
+
+## Recommended Action
+
+1. Use the `ci-simple.yml` workflow for now (disables telemetry)
+2. Report these issues to the atopile project
+3. Once fixed upstream, you can switch back to the standard Docker action
+
+## Testing
+
+To test if the fix works:
+```bash
+# Run locally with Docker
+docker run --rm \
+  -v $(pwd):/github/workspace \
+  -w /github/workspace \
+  -e ATOPILE_TELEMETRY=false \
+  ghcr.io/atopile/atopile-kicad:latest \
+  atopile install
+```

--- a/fix_atopile_errors.py
+++ b/fix_atopile_errors.py
@@ -91,6 +91,16 @@ def patch_dependencies_file(faebryk_path):
         )
         print("Applied generic fix for .message attributes")
     
+    # Fix 3: Specific fix for the error list comprehension at line 298
+    if "error_list = [" in content and "e.message" in content:
+        # Find and fix the specific line causing issues
+        content = re.sub(
+            r'error_list\s*=\s*\[f"{e\.identifier}:\s*{e\.message}"',
+            'error_list = [f"{e.identifier}: {getattr(e, \'message\', getattr(e, \'error\', str(e)))}"',
+            content
+        )
+        print("Applied specific fix for error_list comprehension")
+    
     # Write the patched content if changes were made
     if content != original_content:
         with open(deps_file, 'w') as f:
@@ -107,9 +117,19 @@ def patch_telemetry_file(faebryk_path):
     atopile_patterns = [
         os.path.join(os.path.dirname(faebryk_path), "atopile"),
         os.path.join(os.path.dirname(os.path.dirname(faebryk_path)), "atopile"),
+        # Also check UV tools location
+        "/root/.local/share/uv/tools/atopile/lib/python*/site-packages/atopile",
     ]
     
-    for atopile_path in atopile_patterns:
+    # Expand glob patterns
+    expanded_patterns = []
+    for pattern in atopile_patterns:
+        if '*' in pattern:
+            expanded_patterns.extend(glob.glob(pattern))
+        else:
+            expanded_patterns.append(pattern)
+    
+    for atopile_path in expanded_patterns:
         telemetry_file = os.path.join(atopile_path, "telemetry.py")
         if os.path.exists(telemetry_file):
             print(f"Found telemetry.py at: {telemetry_file}")
@@ -123,22 +143,75 @@ def patch_telemetry_file(faebryk_path):
                 with open(backup_path, 'w') as f:
                     f.write(content)
             
-            # Add a fix to make TelemetryConfig serializable
-            if "yaml.dump(config, f)" in content and "asdict" not in content:
-                # Import dataclasses if not already imported
-                if "from dataclasses import" not in content:
-                    content = "from dataclasses import asdict\n" + content
+            original_content = content
+            
+            # Fix 1: Add dataclasses import if needed
+            if "yaml.dump(config, f)" in content and "from dataclasses import asdict" not in content:
+                # Add import at the top of the file after other imports
+                import_added = False
+                lines = content.split('\n')
+                for i, line in enumerate(lines):
+                    if line.startswith('from ') or line.startswith('import '):
+                        # Find the last import line
+                        continue
+                    elif i > 0 and not line.strip() and not import_added:
+                        # Insert after imports
+                        lines.insert(i, 'from dataclasses import asdict')
+                        import_added = True
+                        break
                 
-                # Replace yaml.dump(config, f) with yaml.dump(asdict(config), f)
+                if not import_added:
+                    # If no imports found, add at the beginning
+                    lines.insert(0, 'from dataclasses import asdict')
+                
+                content = '\n'.join(lines)
+                print("Added dataclasses import")
+            
+            # Fix 2: Replace yaml.dump(config, f) with yaml.dump(asdict(config), f)
+            if "yaml.dump(config, f)" in content:
                 content = re.sub(
                     r'yaml\.dump\(config,\s*f\)',
                     'yaml.dump(asdict(config) if hasattr(config, "__dataclass_fields__") else config, f)',
                     content
                 )
-                
+                print("Fixed yaml.dump to handle dataclass serialization")
+            
+            # Fix 3: Add a custom representer for TelemetryConfig if needed
+            if "TelemetryConfig" in content and "yaml_representer" not in content:
+                # Add a custom representer after the class definition
+                lines = content.split('\n')
+                for i, line in enumerate(lines):
+                    if 'class TelemetryConfig' in line:
+                        # Find the end of the class
+                        indent_level = len(line) - len(line.lstrip())
+                        j = i + 1
+                        while j < len(lines) and (lines[j].strip() == '' or 
+                                                 (lines[j].strip() != '' and 
+                                                  len(lines[j]) - len(lines[j].lstrip()) > indent_level)):
+                            j += 1
+                        
+                        # Insert the representer after the class
+                        representer_code = '''
+# Add YAML representer for TelemetryConfig
+def telemetry_config_representer(dumper, data):
+    return dumper.represent_dict(asdict(data) if hasattr(data, "__dataclass_fields__") else data.__dict__)
+
+try:
+    from ruamel.yaml import YAML
+    YAML.add_representer(TelemetryConfig, telemetry_config_representer)
+except:
+    pass
+'''
+                        lines.insert(j, representer_code)
+                        content = '\n'.join(lines)
+                        print("Added custom YAML representer for TelemetryConfig")
+                        break
+            
+            # Write back if changed
+            if content != original_content:
                 with open(telemetry_file, 'w') as f:
                     f.write(content)
-                print("Patched telemetry.py to handle dataclass serialization")
+                print("Patched telemetry.py")
                 return True
     
     return False


### PR DESCRIPTION
Fix CI build failures in atopile due to telemetry serialization and error attribute issues.

The build failed because atopile's telemetry configuration (a dataclass) could not be serialized by ruamel.yaml, and faebryk's error handling expected a `message` attribute that was sometimes missing on error objects. This PR introduces several workflow options and a more robust patch script to address these upstream bugs, with disabling telemetry being the recommended immediate solution.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1288b0a7-ed41-47d3-856a-f6890144dca0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1288b0a7-ed41-47d3-856a-f6890144dca0)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)