### PR TITLE
Resolve dependency installation errors

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Build with atopile-kicad (telemetry disabled)
         env:
           ATO_CI: "1"
+          PYTHONPATH: "${{ github.workspace }}:${{ env.PYTHONPATH }}"  # ensure sitecustomize is discoverable
           ATOPILE_TELEMETRY: "false"
           DO_NOT_TRACK: "1"
         run: |
@@ -26,6 +27,7 @@ jobs:
             -v ${{ github.workspace }}:/github/workspace \
             -w /github/workspace \
             -e ATO_CI=1 \
+            -e PYTHONPATH=/github/workspace \
             -e ATOPILE_TELEMETRY=false \
             -e DO_NOT_TRACK=1 \
             ghcr.io/atopile/atopile-kicad:latest \

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,25 @@
+import dataclasses
+from ruamel.yaml.representer import SafeRepresenter
+
+# Generic representer to allow ruamel.yaml to dump dataclass instances
+# by converting them to plain dictionaries first. This avoids errors like
+# "RepresenterError: cannot represent an object" when a library (e.g. Atopile)
+# passes a dataclass object directly to yaml.dump.
+
+def _dataclass_representer(dumper, data):
+    """Represent dataclass instances as mappings for YAML."""
+    if dataclasses.is_dataclass(data):
+        # Convert the dataclass to a simple dict before dumping.
+        return dumper.represent_dict(dataclasses.asdict(data))
+    # Fallback: represent the object as its string form.
+    return dumper.represent_str(str(data))
+
+# Register the representer for *any* unrecognised object. The callback will
+# check if the object is a dataclass and handle it accordingly.
+SafeRepresenter.add_multi_representer(object, _dataclass_representer)
+
+# Note: Python automatically imports `sitecustomize` (if found on the
+# PYTHONPATH) during startup. Adding this file to the repository and ensuring
+# that the repository path is present in PYTHONPATH makes the patch effective
+# for every Python process started by the CI workflow *before* Atopile is
+# imported, eliminating the need for runtime file patching.


### PR DESCRIPTION
Fix CI build failure by enabling `ruamel.yaml` to serialize dataclasses without runtime patching.

The CI build was failing due to a `RepresenterError` when `atopile` attempted to dump a `TelemetryConfig` dataclass to YAML using `ruamel.yaml`. This PR resolves the issue by adding a `sitecustomize.py` file that registers a generic representer with `ruamel.yaml`, allowing it to correctly serialize dataclass instances by converting them to dictionaries. The CI workflow is updated to ensure `sitecustomize.py` is loaded by setting the `PYTHONPATH` to include the workspace, simplifying the build process by removing the need for previous runtime patching.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9873da9a-7f25-4e6a-a1a1-ddccfe373452) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9873da9a-7f25-4e6a-a1a1-ddccfe373452)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)