### PR TITLE
Fix ci build dependency errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           ATO_CI: "1"
           ATOPILE_TELEMETRY: "false"
+          PYTHONPATH: "${{ github.workspace }}:$PYTHONPATH"
         continue-on-error: true
         run: |
           docker run --rm \
@@ -25,6 +26,7 @@ jobs:
             -w /github/workspace \
             -e ATO_CI=1 \
             -e ATOPILE_TELEMETRY=false \
+            -e PYTHONPATH=/github/workspace \
             ghcr.io/atopile/atopile-kicad:latest \
             bash -c '
               echo "=== Applying fixes for known atopile/faebryk issues ==="

--- a/docker_fix_script.sh
+++ b/docker_fix_script.sh
@@ -6,6 +6,9 @@ echo "=== Applying atopile/faebryk fixes ==="
 # Disable telemetry
 export ATOPILE_TELEMETRY=false
 export DO_NOT_TRACK=1
+
+# Ensure Python can import our sitecustomize patch (located in repo root)
+export PYTHONPATH="/github/workspace:${PYTHONPATH}"
 mkdir -p ~/.config/atopile
 cat > ~/.config/atopile/config.yaml << EOF
 telemetry: false


### PR DESCRIPTION
Ensure `sitecustomize.py` is loaded in CI to fix dataclass YAML serialization errors.

The CI build was failing with a `RepresenterError` when `ruamel.yaml` attempted to dump `TelemetryConfig` (a dataclass). This is because `ruamel.yaml` doesn't natively support dataclass serialization. The `sitecustomize.py` file in the repository root provides a patch to register a custom representer for dataclasses. By adding the repository root to `PYTHONPATH` in the CI environment and Docker container, `sitecustomize.py` is automatically discovered and imported by Python, resolving the serialization issue.

---

[Open in Web](https://www.cursor.com/agents?id=bc-614a635f-0368-4c11-a5b8-e1e9b2573d9c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-614a635f-0368-4c11-a5b8-e1e9b2573d9c)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)