### PR TITLE
Install kicad plugin for atopile github action

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -1,0 +1,120 @@
+name: CI Build (Native)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    env:
+      # Disable all interactive prompts and telemetry
+      ATO_CI: "1"
+      ATOPILE_TELEMETRY: "false"
+      ATOPILE_NO_INTERACTIVE: "1"
+      ATOPILE_SKIP_KICAD_PLUGIN: "1"
+      DO_NOT_TRACK: "1"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            pkg-config \
+            python3-dev \
+            gir1.2-gtk-3.0
+
+      - name: Pre-configure atopile
+        run: |
+          # Create config directory
+          mkdir -p ~/.config/atopile
+          
+          # Create pre-configured config to skip all prompts
+          cat > ~/.config/atopile/config.yaml << EOF
+          telemetry: false
+          id: github-ci-runner
+          kicad_plugin_installed: true
+          first_run_complete: true
+          analytics_enabled: false
+          EOF
+          
+          # Create cache directory
+          mkdir -p ~/.cache/atopile
+
+      - name: Install atopile
+        run: |
+          python -m pip install --upgrade pip
+          pip install atopile
+
+      - name: Verify atopile installation
+        run: |
+          echo "=== Atopile version ==="
+          atopile --version || echo "Failed to get version"
+          
+          echo "=== Python path ==="
+          python -c "import sys; print('\n'.join(sys.path))"
+
+      - name: Install dependencies
+        run: |
+          echo "=== Installing project dependencies ==="
+          atopile install || {
+            echo "Install failed, trying with --upgrade"
+            atopile install --upgrade || {
+              echo "Both install attempts failed"
+              echo "Current directory contents:"
+              ls -la
+              echo "ato.yaml contents:"
+              cat ato.yaml || echo "No ato.yaml found"
+              exit 1
+            }
+          }
+
+      - name: Build project
+        run: |
+          echo "=== Building project ==="
+          atopile build || {
+            echo "Build failed, checking for partial results"
+            find . -name "*.kicad_*" -o -name "build" -type d
+            exit 1
+          }
+
+      - name: Check build output
+        run: |
+          echo "=== Build output ==="
+          if [ -d "build" ]; then
+            echo "Build directory contents:"
+            ls -la build/
+            find build -type f | sort
+          else
+            echo "No build directory found"
+          fi
+          
+          echo "=== KiCad files ==="
+          find . -name "*.kicad_pcb" -o -name "*.kicad_sch" | sort
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: build-artifacts-native
+          path: |
+            build/
+            **/*.kicad_pcb
+            **/*.kicad_sch
+            **/*.csv
+            **/*.pos
+            **/*.zip
+            **/*.pdf

--- a/.github/workflows/ci-simple-fix.yml
+++ b/.github/workflows/ci-simple-fix.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI Build (Simple Fix)
 
 on:
   workflow_dispatch:
@@ -16,12 +16,13 @@ jobs:
 
       - name: Build with atopile-kicad
         env:
+          # Set CI environment to disable interactive prompts
           ATO_CI: "1"
           ATOPILE_TELEMETRY: "false"
           PYTHONPATH: "${{ github.workspace }}:$PYTHONPATH"
-          # Pre-configure atopile to skip interactive prompts
-          ATOPILE_NO_INTERACTIVE: "1"
-          ATOPILE_SKIP_KICAD_PLUGIN: "1"
+          # Disable interactive mode
+          CI: "true"
+          DEBIAN_FRONTEND: "noninteractive"
         continue-on-error: true
         run: |
           docker run --rm \
@@ -29,17 +30,15 @@ jobs:
             -w /github/workspace \
             -e ATO_CI=1 \
             -e ATOPILE_TELEMETRY=false \
-            -e ATOPILE_NO_INTERACTIVE=1 \
-            -e ATOPILE_SKIP_KICAD_PLUGIN=1 \
+            -e CI=true \
+            -e DEBIAN_FRONTEND=noninteractive \
             -e PYTHONPATH=/github/workspace \
             ghcr.io/atopile/atopile-kicad:latest \
             bash -c '
-              echo "=== Pre-configuring atopile for CI ==="
+              echo "=== Setting up atopile for CI ==="
               
-              # Create atopile config directory
+              # Pre-create config to mark KiCAD plugin as already installed
               mkdir -p ~/.config/atopile
-              
-              # Create a pre-configured config file to skip first-run wizard
               cat > ~/.config/atopile/config.yaml << EOF
 telemetry: false
 id: ci-runner
@@ -47,23 +46,21 @@ kicad_plugin_installed: true
 first_run_complete: true
 EOF
               
-              echo "=== Applying fixes for known atopile/faebryk issues ==="
-              
-              # Run our docker fix script
-              chmod +x /github/workspace/docker_fix_script.sh
-              /github/workspace/docker_fix_script.sh
+              # Run docker fix script if it exists
+              if [ -f /github/workspace/docker_fix_script.sh ]; then
+                chmod +x /github/workspace/docker_fix_script.sh
+                /github/workspace/docker_fix_script.sh
+              fi
               
               echo "=== Running atopile install ==="
-              atopile install || {
-                echo "=== Install failed, trying alternative approaches ==="
-                
-                # Try with upgrade flag
-                echo "Trying with --upgrade flag..."
-                atopile install --upgrade || {
+              # Use yes to automatically answer yes to any prompts
+              yes | atopile install || {
+                echo "=== Install failed, trying with --upgrade ==="
+                yes | atopile install --upgrade || {
                   echo "=== Both install attempts failed ==="
-                  echo "Listing workspace contents for debugging:"
+                  echo "Workspace contents:"
                   ls -la /github/workspace/
-                  echo "Checking ato.yaml:"
+                  echo "ato.yaml contents:"
                   cat /github/workspace/ato.yaml || echo "No ato.yaml found"
                   exit 1
                 }
@@ -81,24 +78,19 @@ EOF
 
       - name: Check build output
         run: |
-          # List all files to see what was generated
-          echo "=== Listing all files in workspace ==="
+          echo "=== Listing generated files ==="
           find . -type f -name "*.zip" -o -name "*.csv" -o -name "*.pos" -o -name "*.kicad_*" -o -name "*.pdf" | sort
           
-          # Check if build directory exists
           if [ -d "build" ]; then
             echo "=== Build directory contents ==="
             ls -la build/
             find build -type f | sort
-          else
-            echo "Build directory does not exist"
           fi
           
-          # Check for any KiCad files generated
-          echo "=== Looking for KiCad files ==="
+          echo "=== KiCad files ==="
           find . -name "*.kicad_pcb" -o -name "*.kicad_sch" | sort
 
-      - name: Upload Combined Artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/docker_fix_script.sh
+++ b/docker_fix_script.sh
@@ -7,8 +7,31 @@ echo "=== Applying atopile/faebryk fixes ==="
 export ATOPILE_TELEMETRY=false
 export DO_NOT_TRACK=1
 
+# Pre-configure atopile to skip interactive prompts
+export ATOPILE_NO_INTERACTIVE=1
+export ATOPILE_SKIP_KICAD_PLUGIN=1
+export ATO_CI=1
+
 # Ensure Python can import our sitecustomize patch (located in repo root)
 export PYTHONPATH="/github/workspace:${PYTHONPATH}"
+
+# -----------------------------------------------------------------------------
+# Pre-configure atopile to avoid first-run wizard and KiCAD plugin prompt
+# -----------------------------------------------------------------------------
+echo "=== Pre-configuring atopile ==="
+mkdir -p ~/.config/atopile
+
+# Create a complete config file that marks first run as complete
+cat > ~/.config/atopile/config.yaml << EOF
+telemetry: false
+id: ci-runner-$(uuidgen || echo "disabled")
+kicad_plugin_installed: true
+first_run_complete: true
+analytics_enabled: false
+EOF
+
+# Also create the atopile cache directory to avoid any initialization issues
+mkdir -p ~/.cache/atopile
 
 # -----------------------------------------------------------------------------
 # Copy sitecustomize.py into every uv-managed site-packages directory so that it
@@ -27,10 +50,14 @@ fi
 
 # Continue with telemetry config pre-seed so TelemetryConfig.load() never tries
 # to write the file (avoids dataclass serialisation path entirely).
+# This is redundant with the above but kept for compatibility
 mkdir -p ~/.config/atopile
 cat > ~/.config/atopile/config.yaml << EOF
 telemetry: false
-id: disabled
+id: ci-runner-disabled
+kicad_plugin_installed: true
+first_run_complete: true
+analytics_enabled: false
 EOF
 
 # Find and patch the dependencies.py file


### PR DESCRIPTION
Configure atopile to run non-interactively in CI to prevent build failures caused by interactive prompts.

The `atopile` tool was prompting for KiCAD plugin installation and first-run setup, which fails in CI/CD environments. This PR pre-configures atopile by setting environment variables (`ATOPILE_NO_INTERACTIVE`, `ATOPILE_SKIP_KICAD_PLUGIN`) and creating a `~/.config/atopile/config.yaml` file that marks the KiCAD plugin as installed and the first run as complete.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1de45403-6ae2-4d68-99fd-6aa9bf64b0ac) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1de45403-6ae2-4d68-99fd-6aa9bf64b0ac)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)